### PR TITLE
fix potential overflow that can lead to infinite loop in file reading

### DIFF
--- a/forcing_code/src/bmi_aorc.c
+++ b/forcing_code/src/bmi_aorc.c
@@ -480,7 +480,11 @@ int read_file_line_counts_aorc(const char* file_name, int* line_count, int* max_
         return -1;
     }
     int seen_non_whitespace = 0;
-    char c;
+    int c; //EOF is a negative constant...and char may be either signed OR unsigned
+    //depending on the compiler, system, achitectured, ect.  So there are cases
+    //where this loop could go infinite comparing EOF to unsigned char
+    //the return of fgetc is int, and should be stored as such!
+    //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
         // keep track if this line has seen any char other than space or tab
         if (c != ' ' && c != '\t' && c != '\n')

--- a/forcing_code/src/bmi_pet.c
+++ b/forcing_code/src/bmi_pet.c
@@ -497,7 +497,11 @@ int read_file_line_counts_pet(const char* file_name, int* line_count, int* max_l
         return -1;
     }
     int seen_non_whitespace = 0;
-    char c;
+    int c; //EOF is a negative constant...and char may be either signed OR unsigned
+    //depending on the compiler, system, achitectured, ect.  So there are cases
+    //where this loop could go infinite comparing EOF to unsigned char
+    //the return of fgetc is int, and should be stored as such!
+    //https://stackoverflow.com/questions/35356322/difference-between-int-and-char-in-getchar-fgetc-and-putchar-fputc
     for (c = fgetc(fp); c != EOF; c = fgetc(fp)) {
         // keep track if this line has seen any char other than space or tab
         if (c != ' ' && c != '\t' && c != '\n')


### PR DESCRIPTION
A potential overflow bug exists in the `read_file_line_counts` function.  Depending on system, compiler, and hardware, this can lead to a infinite loop.

## Changes

- Change the i/o buffer type for character reading to `int` from `char` to avoid overflowing a possible unsigned char type.

## Testing

1. Tested through ngen unit tests

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Linux (x86 and arm)
- [x] MacOS (x86 and arm)

