### PR TITLE
Update soil param variable names

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -5,10 +5,10 @@ A detailed description of the parameters for model configuration (i.e., initiali
 | Variable ______________ | Datatype ________ | Limits ______ | Units ______ | Role _____ |  Description __________________________________________________ |
 | ------ | -------- | ------ | ----- | ---- | ----------- |
 | forcing_file | string | - | - | filename | provides ground temperature (not needed when coupled to models providing ground temperature data|
-| *smcmax | double | - | - | state variable | maximum soil moisture content (porosity) |
-| *b | double | - | m | state variable | pore size distribution, beta exponent in Clapp-Hornberger characteristic function |
-| *satpsi | double | - | m | state variable | saturated capillary head (saturated moisture potential) |
-| quartz | double | - | m | state variable | soil quartz content, used in soil thermal conductivity function of Peters-Lidard |
+| *soil_params.smcmax | double | - | - | state variable | maximum soil moisture content (porosity) |
+| *soil_params.b | double | - | m | state variable | pore size distribution, beta exponent in Clapp-Hornberger characteristic function |
+| *soil_params.satpsi | double | - | m | state variable | saturated capillary head (saturated moisture potential) |
+| soil_params.quartz | double | - | m | state variable | soil quartz content, used in soil thermal conductivity function of Peters-Lidard |
 | ice_fraction_scheme | int | - | - | coupling variable | runoff scheme used in the soil reservoir models (e.g. CFE), options: Schaake and Xinanjiang|
 | soil_z | double (1D array) | - | m | spatial resolution | vertical resolution of the soil column (computational domain of the SFT model) |
 | soil_temperature | double (1D array) | - | K | spatial resolution | initial soil temperature for the discretized column |


### PR DESCRIPTION
Small updates to config file readme. It seems that soil parameter values are specified as `soil_params.<x>` in the config file, however they are specified using _only_ their qualifying name (e.g. `b`, `quartz`) if they are being calibrated. Can you verify this, @ajkhattak?

`b` -> `soil_params.b`
https://github.com/NOAA-OWP/SoilFreezeThaw/blob/14610e3f0c69cbfb62564b19b8f5762e7c6aef63/src/soil_freeze_thaw.cxx#L181 

`quartz` -> `soil_params.quartz`
https://github.com/NOAA-OWP/SoilFreezeThaw/blob/14610e3f0c69cbfb62564b19b8f5762e7c6aef63/src/soil_freeze_thaw.cxx#L188

`satpsi` -> `soil_params.satpsi`
https://github.com/NOAA-OWP/SoilFreezeThaw/blob/14610e3f0c69cbfb62564b19b8f5762e7c6aef63/src/soil_freeze_thaw.cxx#L194

`smcmax` -> `soil_params.smcmax`
https://github.com/NOAA-OWP/SoilFreezeThaw/blob/14610e3f0c69cbfb62564b19b8f5762e7c6aef63/src/soil_freeze_thaw.cxx#L176