### PR TITLE
Accept short and long form of soil_params in config

### DIFF
--- a/src/soil_freeze_thaw.cxx
+++ b/src/soil_freeze_thaw.cxx
@@ -173,25 +173,33 @@ InitFromConfigFile(std::string config_file)
       is_soil_z_set = true;
       continue;
     }
-    else if (param_key == "soil_params.smcmax") {
+    // NOTE: `soil_params.smcmax` may be deprecated in the future.
+    // See https://github.com/NOAA-OWP/SoilFreezeThaw/pull/14#issuecomment-1864879127 for discussion
+    else if (param_key == "smcmax" || param_key == "soil_params.smcmax") {
       this->smcmax = std::stod(param_value);
       is_smcmax_set = true;
       continue;
     }
-    else if (param_key == "soil_params.b") {
+    // NOTE: `soil_params.b` may be deprecated in the future.
+    // See https://github.com/NOAA-OWP/SoilFreezeThaw/pull/14#issuecomment-1864879127 for discussion
+    else if (param_key == "b" || param_key == "soil_params.b") {
       this->b = std::stod(param_value);
       std::string b_unit = line.substr(loc_u+1,line.length());
       assert (this->b > 0);
       is_b_set = true;
       continue;
     }
-    else if (param_key == "soil_params.quartz") {
+    // NOTE: `soil_params.quartz` may be deprecated in the future.
+    // See https://github.com/NOAA-OWP/SoilFreezeThaw/pull/14#issuecomment-1864879127 for discussion
+    else if (param_key == "quartz" || param_key == "soil_params.quartz") {
       this->quartz = std::stod(param_value);
       assert (this->quartz > 0);
       is_quartz_set = true;
       continue;
     }
-    else if (param_key == "soil_params.satpsi") {  //Soil saturated matrix potential
+    // NOTE: `soil_params.satpsi` may be deprecated in the future.
+    // See https://github.com/NOAA-OWP/SoilFreezeThaw/pull/14#issuecomment-1864879127 for discussion
+    else if (param_key == "satpsi" || param_key == "soil_params.satpsi") {  //Soil saturated matrix potential
       this->satpsi = std::stod(param_value);
       is_satpsi_set = true;
       continue;


### PR DESCRIPTION
In the future the long forms may be deprecated. However, for now, the following options are aliased. If both the long and short forms are specified in a config file, the last one specified wins.

b      <=> soil_params.b
quartz <=> soil_params.quartz
satpsi <=> soil_params.satpsi
smcmax <=> soil_params.smcmax

related to #14 
closes #14