### PR TITLE
Update unit test exit codes

### DIFF
--- a/tests/main_unittest.cxx
+++ b/tests/main_unittest.cxx
@@ -12,7 +12,8 @@
 #include "../include/bmi_soil_freeze_thaw.hxx"
 #include "../include/soil_freeze_thaw.hxx"
 
-#define FAILURE 0
+#define SUCCESS 0
+#define FAILURE 1
 #define VERBOSITY 1
 
 #define GREEN "\033[32m"
@@ -322,7 +323,7 @@ int main(int argc, char *argv[])
     //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     // Test get_grid_rank()
     grid_rank = model.GetGridRank(grid_id[i]);
-    if (grid_rank == FAILURE) return FAILURE;
+    if (grid_rank == 0) return FAILURE;
     if (VERBOSITY)
       std::cout<<" rank: "<<grid_rank<<"\n";
 
@@ -649,5 +650,5 @@ int main(int argc, char *argv[])
     model_calib.Update();
   }
   
-  return FAILURE;
+  return test_status ? SUCCESS : FAILURE;
 }

--- a/tests/run_unittest.sh
+++ b/tests/run_unittest.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 ${CXX} -lm -Wall -O -g ./main_unittest.cxx ../src/bmi_soil_freeze_thaw.cxx ../src/soil_freeze_thaw.cxx -o run_sft
 ./run_sft configs/unittest.txt
+test_pass=$?
 rm -f run_sft
 rm -rf run_sft.dSYM
+exit $test_pass


### PR DESCRIPTION
Minor quality of life changes to unit tests and unit test script. Both tests and script exit with 0 (bash true) on success and 1 on failure (bash false). 