### PR TITLE
Config, install, readme & realization updates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -49,47 +49,68 @@ We provide three examples here to run and test SFT (coupled/uncoupled modes) in 
 
 ### Build
 See general [instructions](https://github.com/NOAA-OWP/ngen/wiki/NGen-Tutorial#running-cfe) for building models in the ngen framework. 
-- ### Specific instructions for building an integrated system
-  - git clone https://github.com/noaa-owp/ngen && cd ngen
-  - git submodule update --init --recursive
-  - #### fortran bmi
-    - cmake -B extern/iso_c_fortran_bmi/cmake_build -S extern/iso_c_fortran_bmi
-    - make -C extern/iso_c_fortran_bmi/cmake_build
-  - #### build ngen
-     - cmake -B cmake_build -S . -DNGEN_WITH_BMI_C=ON -DNGEN_WITH_BMI_FORTRAN=ON -DNGEN_WITH_PYTHON=ON
-       -DNGEN_WITH_SQLITE=ON
-     - make -j4 -C cmake_build
-  - #### CFE
-    - git submodule update --remote extern/cfe/cfe 
-    - cmake -B extern/cfe/cfe/cmake_build -S extern/cfe/cfe/ -DNGEN=ON
-    - make -C extern/cfe/cfe/cmake_build
-  - #### LASAM
-    - git clone https://github.com/NOAA-OWP/LGAR-C extern/LASAM
-    - git submodule update --remote extern/SoilFreezeThaw/SoilFreezeThaw  
-    - cmake -B extern/LASAM/LASAM/cmake_build -S extern/LASAM/ -DNGEN=ON
-    - make -C extern/LASAM/LASAM/cmake_build
-  - #### NOAH-OWP-Modular
-    - cmake -B extern/noah-owp-modular/noah-owp-modular/cmake_build -S extern/noah-owp-modular
-    - make -C extern/noah-owp-modular/noah-owp-modular/cmake_build
-  - #### PET
-    - cmake -B extern/evapotranspiration/evapotranspiration/cmake_build -S extern/evapotranspiration/evapotranspiration/
-    - make -C extern/evapotranspiration/evapotranspiration/cmake_build/
-  - #### SFT
-    - git submodule update --remote extern/SoilFreezeThaw/SoilFreezeThaw  
-    - cmake -B extern/SoilFreezeThaw/SoilFreezeThaw/cmake_build -S extern/SoilFreezeThaw/SoilFreezeThaw/ -DNGEN=ON
-    - make -C extern/SoilFreezeThaw/SoilFreezeThaw/cmake_build
-  - #### SMP
-    - git submodule update --remote extern/SoilMoistureProfiles/SoilMoistureProfiles
-    - cmake -B extern/SoilMoistureProfiles/SoilMoistureProfiles/cmake_build -S extern/SoilMoistureProfiles/SoilMoistureProfiles/ -DNGEN=ON
-    - make -C extern/SoilMoistureProfiles/SoilMoistureProfiles/cmake_build
- 
-  - #### SLoTH
-    SLoTH is also needed to run SFT in the ngen framework. SLoTH is a BMI that is used to set a bmi variable(s) that is not provided by other BMIs but required by the model. So build [SLoTH](https://github.com/NOAA-OWP/SLoTH) using the following instructions
-    - cd extern/sloth/ && git checkout latest 
-    - git submodule update --init --recursive
-    - cd ../..
-    - cmake -B extern/sloth/cmake_build -S extern/sloth/
-    - make -C extern/sloth/cmake_build
+
+Specific instructions for building an integrated system:
+
+#### 1. Clone ngen & extract submodules
+```
+git clone https://github.com/noaa-owp/ngen && cd ngen
+git submodule update --init --recursive
+```
+#### 2. Fortran BMI
+To use the noah-owp-modular fortran library, we need to build the iso_c_fortran_bmi middleware.
+```
+cmake -B extern/iso_c_fortran_bmi/cmake_build -S extern/iso_c_fortran_bmi
+make -C extern/iso_c_fortran_bmi/cmake_build
+```
+#### 3. CFE
+```
+git submodule update --remote extern/cfe/cfe 
+cmake -B extern/cfe/cfe/cmake_build -S extern/cfe/cfe/ -DNGEN=ON
+make -C extern/cfe/cfe/cmake_build
+```
+#### 4. LASAM
+```
+git clone https://github.com/NOAA-OWP/LGAR-C extern/LASAM
+cmake -B extern/LASAM/LASAM/cmake_build -S extern/LASAM/ -DNGEN=ON
+make -C extern/LASAM/LASAM/cmake_build
+```
+#### 5. NOAH-OWP-Modular
+```
+cmake -B extern/noah-owp-modular/noah-owp-modular/cmake_build -S extern/noah-owp-modular -DNGEN_IS_MAIN_PROJECT=ON
+make -C extern/noah-owp-modular/noah-owp-modular/cmake_build
+```
+#### 6. PET
+```
+cmake -B extern/evapotranspiration/evapotranspiration/cmake_build -S extern/evapotranspiration/evapotranspiration/
+make -C extern/evapotranspiration/evapotranspiration/cmake_build/
+```
+#### 7. SFT
+```
+git submodule update --remote extern/SoilFreezeThaw/SoilFreezeThaw  
+cmake -B extern/SoilFreezeThaw/SoilFreezeThaw/cmake_build -S extern/SoilFreezeThaw/SoilFreezeThaw/ -DNGEN=ON
+make -C extern/SoilFreezeThaw/SoilFreezeThaw/cmake_build
+```
+#### 8. SMP
+```
+git submodule update --remote extern/SoilMoistureProfiles/SoilMoistureProfiles
+cmake -B extern/SoilMoistureProfiles/SoilMoistureProfiles/cmake_build -S extern/SoilMoistureProfiles/SoilMoistureProfiles/ -DNGEN=ON
+make -C extern/SoilMoistureProfiles/SoilMoistureProfiles/cmake_build
+```
+#### 9. SLoTH
+SLoTH is also needed to run SFT in the ngen framework. SLoTH is a BMI that is used to set a bmi variable(s) that is not provided by other BMIs but required by the model. So build [SLoTH](https://github.com/NOAA-OWP/SLoTH) using the following instructions.
+```
+cd extern/sloth/ && git checkout latest 
+git submodule update --init --recursive
+cd ../..
+cmake -B extern/sloth/cmake_build -S extern/sloth/
+make -C extern/sloth/cmake_build
+```
+#### 10. Build ngen
+```
+cmake -B cmake_build -S . -DNGEN_WITH_BMI_C=ON -DNGEN_WITH_BMI_FORTRAN=ON -DNGEN_WITH_PYTHON=ON -DNGEN_WITH_SQLITE=ON
+make -j4 -C cmake_build
+```
 
 ### Run
 The following pre-process step needs to be completed before running the below examples.

--- a/configs/extern/laramie_config_cfe.txt
+++ b/configs/extern/laramie_config_cfe.txt
@@ -21,5 +21,5 @@ giuh_ordinates=0.06,0.51,0.28,0.12,0.03
 num_timesteps=1
 verbosity=1
 surface_partitioning_scheme=Schaake
-sft_coupled=true
+is_sft_coupled=true
 ice_content_threshold=0.15

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,11 +1,11 @@
 # Nextgen SFT Examples
 The directory contains two example realization files using CFE and LASAM as soil reservoir models integrated with NOAH-OWP-Mod (NOM), Soil Freeze-thaw (SFT), and Soil Moisture Profiles (SMP). The realizations use the HUC01 catchment (cat-20521) as an example. Follow the instructions below to run these examples. To build the nextgen framework and models see [INSTALL.md](https://github.com/NOAA-OWP/SoilFreezeThaw/blob/master/INSTALL.md).
 
-**Note:** Your working directory could be anywhere to run these examples, however, it is recommended to work and create the `test` directory out of the `ngen` directory. Assuming you have cloned the SoilFreezeThaw model already, follow the below steps. Also, don't forget to edit `path_to_ngen_dir` lines to adjust them to your local paths.
+**Note:** Your working directory could be anywhere to run these examples, however, it is recommended to work and create the `test_sft` directory out of the `ngen` directory. Assuming you have cloned the SoilFreezeThaw model already, follow the below steps. Also, don't forget to edit `path_to_ngen_dir` lines to adjust them to your local paths.
 ```
-mkdir test
-cp -r /path_to_ngen_dir/extern/SoilFreezeThaw/SoilFreezeThaw/examples/ test
-cd test
+mkdir test_sft
+cp -r /path_to_ngen_dir/extern/SoilFreezeThaw/SoilFreezeThaw/examples/ test_sft
+cd test_sft
 ln -s path_to_ngen_dir ngen
-./ngen/cmake_build/ngen ./ngen/data/catchment_data.geojson cat-27 ./ngen/data/nexus_data.geojson nex-26 realizations/realization_X.json (where X = cfe or lasam)
+./ngen/cmake_build/ngen ./ngen/data/catchment_data.geojson cat-27 ./ngen/data/nexus_data.geojson nex-26 realizations/realization_<*>.json (where <*> = cfe or lasam)
 ```

--- a/examples/configs/lasam/cat-20521.txt
+++ b/examples/configs/lasam/cat-20521.txt
@@ -11,6 +11,6 @@ layer_soil_type=13,14,15
 max_soil_types=25
 wilting_point_psi=15495.0[cm]
 giuh_ordinates=0.06,0.51,0.28,0.12,0.03
-sft_coupled=true
+is_sft_coupled=true
 #soil_z=10,20,30,40,50,60,70,80,90,100.0,110.,120,130.,140.,150.,160.,170.,180.,190.,200.0[cm]
 soil_z=10,30,100.0,200.0[cm]

--- a/realizations/realization_standalone.json
+++ b/realizations/realization_standalone.json
@@ -46,7 +46,7 @@
 				"name": "bmi_c++",
 				"params": {
 				    "model_type_name": "bmi_sft",
-				    "library_file": "./extern/SoilFreezeThaw/cmake_build/libsftbmi",
+				    "library_file": "./extern/SoilFreezeThaw/SoilFreezeThaw/cmake_build/libsftbmi",
 				    "init_config": "./configs/laramie_config_standalone.txt",
 				    "allow_exceed_end_time": true,
 				    "main_output_variable": "num_cells",


### PR DESCRIPTION
Minor non-code updates

## Changes

1. config.txt(s): all instances of `sft_coupled` to `is_sft_coupled` per [cfe pr #105](https://github.com/NOAA-OWP/cfe/pull/105)
2. INSTALL.md: 
   1. add `-DNGEN_IS_MAIN_PROJECT=ON` flag to the noah-owp-modular lib build
   2. Remove sft `submodule update` from LASAM build (not officially listed in `ngen/extern`)
   3. Some markdown syntax changes for better c/p
3. example/README.md: dir `test` already exists, suggest `ngen/test_sft`
4. realizations/realization_standalone.json: update sft lib path

## Todos

1. Need to revisit the [instructions](https://github.com/NOAA-OWP/SoilFreezeThaw/blob/master/examples/README.md#nextgen-sft-examples) for "Example 3: Integrated models (SLoTH+SMP+SFT+CFE/LASAM) example with NOAH-OWP-Mod".  Perhaps some pathing and/or symbolic linkage is off?
2. Couple general questions regarding [install](https://github.com/NOAA-OWP/SoilFreezeThaw/blob/master/INSTALL.md),
   1. Why are we updating some submodules but not others?
   2. Why `ngen` build to include `PYTHON` and `SQLITE` for this particular workflow(s)?
