### PR TITLE
Update BMI C++ header to match upstream with virtual dtor

### DIFF
--- a/bmi/bmi.hxx
+++ b/bmi/bmi.hxx
@@ -6,13 +6,14 @@
 
 #ifndef BMI_HXX
 #define BMI_HXX
+
 #include <string>
 #include <vector>
 
-namespace bmixx {
+namespace bmi {
 
-  //const int BMI_SUCCESS = 0;
-  //  const int BMI_FAILURE = 1;
+  const int BMI_SUCCESS = 0;
+  const int BMI_FAILURE = 1;
 
   const int MAX_COMPONENT_NAME = 2048;
   const int MAX_VAR_NAME = 2048;
@@ -21,6 +22,8 @@ namespace bmixx {
 
   class Bmi {
     public:
+      virtual ~Bmi() { }
+
       // Model control functions.
       virtual void Initialize(std::string config_file) = 0;
       virtual void Update() = 0;

--- a/include/bmi_soil_freeze_thaw.hxx
+++ b/include/bmi_soil_freeze_thaw.hxx
@@ -14,7 +14,7 @@ class NotImplemented : public std::logic_error {
 };
 
 
-class BmiSoilFreezeThaw : public bmixx::Bmi {
+class BmiSoilFreezeThaw : public bmi::Bmi {
   public:
     BmiSoilFreezeThaw() {
       this->input_var_names[0]  = "ground_temperature";


### PR DESCRIPTION
Cf NOAA-OWP/ngen#831

## Changes

- Update the definition of the base class Bmi to match upstream with its virtual destructor
- Use the same namespace bmi as upstream, and not a custom namespace bmixx to avoid UB

## Testing

1. CI

## Notes

These PRs need to be merged in tandem:
* NOAA-OWP/ngen#832
* NOAA-OWP/SLoTH#7
* https://github.com/NOAA-OWP/SoilMoistureProfiles/pull/17
* NOAA-OWP/SoilFreezeThaw#25
* NOAA-OWP/LGAR-C#26

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: